### PR TITLE
Suite name

### DIFF
--- a/packages/reporter/index.ts
+++ b/packages/reporter/index.ts
@@ -29,10 +29,8 @@ export class VisualRegressionReport {
     });
   }
 
-  saveTestContext(context: any): void {
-    const { passed, testName } = this.transformContext(context);
-    
-    this.lastTestCase = { ...this.lastTestCase, passed, testName };
+  saveTestContext(context: Partial<TestContextResult>): void {
+    this.lastTestCase = { ...this.lastTestCase, ...context };
     this.report.push(this.lastTestCase as ReportData);
     this.lastTestCase = { matchers: [] };
   }
@@ -54,10 +52,5 @@ export class VisualRegressionReport {
     if (existsSync(report)) {
       unlinkSync(report);
     }
-  }
-
-  private transformContext(context: any): Partial<TestContextResult> {
-    // TODO: Tested with mocha and jasmine
-    return { testName: context.title, passed: context.passed };
   }
 }

--- a/packages/reporter/interfaces.d.ts
+++ b/packages/reporter/interfaces.d.ts
@@ -11,7 +11,6 @@ interface MatchCommandResult {
 export type TestContextResult = Omit<ReportData, 'matchers'>;
 
 export interface ReportData {
-  suiteName: string;
   testName: string;
   passed: boolean;
   matchers: MatchCommandResult[];

--- a/packages/reporter/interfaces.d.ts
+++ b/packages/reporter/interfaces.d.ts
@@ -11,7 +11,7 @@ interface MatchCommandResult {
 export type TestContextResult = Omit<ReportData, 'matchers'>;
 
 export interface ReportData {
-  suiteName?: string;
+  suiteName: string;
   testName: string;
   passed: boolean;
   matchers: MatchCommandResult[];

--- a/packages/reporter/interfaces.d.ts
+++ b/packages/reporter/interfaces.d.ts
@@ -11,6 +11,7 @@ interface MatchCommandResult {
 export type TestContextResult = Omit<ReportData, 'matchers'>;
 
 export interface ReportData {
+  suiteName: string;
   testName: string;
   passed: boolean;
   matchers: MatchCommandResult[];

--- a/packages/reporter/interfaces.d.ts
+++ b/packages/reporter/interfaces.d.ts
@@ -11,6 +11,7 @@ interface MatchCommandResult {
 export type TestContextResult = Omit<ReportData, 'matchers'>;
 
 export interface ReportData {
+  suiteName?: string;
   testName: string;
   passed: boolean;
   matchers: MatchCommandResult[];

--- a/packages/service/index.ts
+++ b/packages/service/index.ts
@@ -38,8 +38,19 @@ export class VisualRegression {
   }
 
   afterTest(context: any) {
+    const testName = context.title;
+    let suiteName = '';
+    // TODO: Tested with jasmine
+    if (context.fullTitle.endsWith(testName)) {
+      suiteName = context.fullTitle.substr(0, context.fullTitle.length - testName.length).trim();
+    }
+
     // TODO: Tested with mocha and jasmine
-    this.report.saveTestContext({ testName: context.title, passed: context.passed });
+    this.report.saveTestContext({
+      suiteName,
+      testName,
+      passed: context.passed
+    });
   }
 
   afterScenario(uri: string, feature: any, scenario: any, result: any) {

--- a/packages/service/index.ts
+++ b/packages/service/index.ts
@@ -38,15 +38,24 @@ export class VisualRegression {
   }
 
   afterTest(context: any) {
+    const testName = context.title;
+    let suiteName = '';
+    // TODO: Tested with jasmine
+    if (context.fullTitle.endsWith(testName)) {
+      suiteName = context.fullTitle.substr(0, context.fullTitle.length - testName.length).trim();
+    }
+
     // TODO: Tested with mocha and jasmine
     this.report.saveTestContext({
-      testName: context.title,
+      suiteName,
+      testName,
       passed: context.passed
     });
   }
 
   afterScenario(uri: string, feature: any, scenario: any, result: any) {
     this.report.saveTestContext({
+      suiteName: feature.document.feature.name,
       testName: scenario.name,
       passed: result.status === 'passed'
     });

--- a/packages/service/index.ts
+++ b/packages/service/index.ts
@@ -38,7 +38,16 @@ export class VisualRegression {
   }
 
   afterTest(context: any) {
-    this.report.saveTestContext(context);
+    // TODO: Tested with mocha and jasmine
+    this.report.saveTestContext({ testName: context.title, passed: context.passed });
+  }
+
+  afterScenario(uri: string, feature: any, scenario: any, result: any) {
+    this.report.saveTestContext({
+      suiteName: feature.document.feature.name,
+      testName: scenario.name,
+      passed: result.status === 'passed'
+    });
   }
 
   after() {

--- a/packages/service/index.ts
+++ b/packages/service/index.ts
@@ -38,24 +38,15 @@ export class VisualRegression {
   }
 
   afterTest(context: any) {
-    const testName = context.title;
-    let suiteName = '';
-    // TODO: Tested with jasmine
-    if (context.fullTitle.endsWith(testName)) {
-      suiteName = context.fullTitle.substr(0, context.fullTitle.length - testName.length).trim();
-    }
-
     // TODO: Tested with mocha and jasmine
     this.report.saveTestContext({
-      suiteName,
-      testName,
+      testName: context.title,
       passed: context.passed
     });
   }
 
   afterScenario(uri: string, feature: any, scenario: any, result: any) {
     this.report.saveTestContext({
-      suiteName: feature.document.feature.name,
       testName: scenario.name,
       passed: result.status === 'passed'
     });


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other


## What is the current behavior?

Only the test name ist put into the report.

## What is the new behavior?

An additional suite name is added to the report.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This PR is split from #9.

Other options besides the way it is implemented now could be:

- don't add a suiteName but a fullTestName which would be `fullTitle` in case of jasmine/mocha, and `feature.name + ' ' + scenario.name` in case of cucumber
- treat cucumber and jasmine/mocha differently