### PR TITLE
Option for case no expected image

### DIFF
--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -7,6 +7,7 @@
 | `customMatchers`      |`Function[]`|false     | [ ]            | Add custom matchers to webdriverio                                    |
 | `largeImageThreshold` |`number`    |false     | 1200           | Skips pixels when the image width or height is larger than this one   |
 | `allowedMismatch`     |`number`    |false     | 0.1            | Ignore failed result if mismatch percentage less than allowed         |
+| `initiateExpectedImage` |`boolean` |false     | true           | Use actual image if no expected image is provided; returns mismatch positive infinity if set to false |
 
 #### instanceFolder
 

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -7,7 +7,7 @@
 | `customMatchers`      |`Function[]`|false     | [ ]            | Add custom matchers to webdriverio                                    |
 | `largeImageThreshold` |`number`    |false     | 1200           | Skips pixels when the image width or height is larger than this one   |
 | `allowedMismatch`     |`number`    |false     | 0.1            | Ignore failed result if mismatch percentage less than allowed         |
-| `initiateExpectedImage` |`boolean` |false     | true           | Use actual image if no expected image is provided; returns mismatch positive infinity if set to false |
+| `initiateExpectedImage` |`boolean` |false     | true           | Use actual image if no expected image is provided; returns mismatch of positive infinity if set to false |
 
 #### instanceFolder
 

--- a/packages/config.ts
+++ b/packages/config.ts
@@ -8,6 +8,7 @@ const DEFAULT_FOLDER = 'regression';
 const DEFAULT_MATCHERS = [ViewportMatcher, ElementMatcher];
 const DEFAULT_ALLOWED_MISMATCH = 0.1;
 const LARGE_IMAGE_THRESHOLD = 1200;
+const DEFAULT_INITIATE_EXPECTED_IMAGE = true;
 
 interface ConfigOptions extends Omit<ServiceOptions, 'instanceFolder'> { 
   instanceFolder?: string;
@@ -47,6 +48,10 @@ export class Config {
     return {
       largeImageThreshold: this.options.largeImageThreshold ?? LARGE_IMAGE_THRESHOLD
     }
+  }
+
+  get initiateExpectedImage(): boolean {
+    return this.options.initiateExpectedImage ?? DEFAULT_INITIATE_EXPECTED_IMAGE
   }
 
   private constructor() { /* pass */ }

--- a/packages/interfaces.d.ts
+++ b/packages/interfaces.d.ts
@@ -12,4 +12,5 @@ export interface ServiceOptions {
   customMatchers?: (AnyObject | string)[];
   largeImageThreshold?: number;
   allowedMismatch?: number;
+  initiateExpectedImage?: boolean;
 }

--- a/packages/service/core/match.ts
+++ b/packages/service/core/match.ts
@@ -10,11 +10,13 @@ export async function match(filename: string, takeScreenshot: () => Promise<Buff
   
   saveImage(filename, Subfolder.ACTUAL, actualImage);
 
-  if (!expectedImage && config.initiateExpectedImage) {
-    saveImage(filename, Subfolder.EXPECTED, actualImage);
-    expectedImage = actualImage;
-  } else if (!expectedImage && !config.initiateExpectedImage) {
-    return Number.POSITIVE_INFINITY
+  if (!expectedImage) {
+    if (config.initiateExpectedImage) {
+      saveImage(filename, Subfolder.EXPECTED, actualImage);
+      expectedImage = actualImage;
+    } else {
+      return Number.POSITIVE_INFINITY
+    }
   }
 
   const result = await compare(expectedImage, actualImage, { output: config.ressembleOutput });

--- a/packages/service/core/match.ts
+++ b/packages/service/core/match.ts
@@ -8,9 +8,13 @@ export async function match(filename: string, takeScreenshot: () => Promise<Buff
   const actualImage = await takeScreenshot();
   let expectedImage = getImage(filename, Subfolder.EXPECTED);
   
-  if (!expectedImage) {
+  saveImage(filename, Subfolder.ACTUAL, actualImage);
+
+  if (!expectedImage && config.initiateExpectedImage) {
     saveImage(filename, Subfolder.EXPECTED, actualImage);
     expectedImage = actualImage;
+  } else if (!expectedImage && !config.initiateExpectedImage) {
+    return Number.POSITIVE_INFINITY
   }
 
   const result = await compare(expectedImage, actualImage, { output: config.ressembleOutput });
@@ -22,7 +26,5 @@ export async function match(filename: string, takeScreenshot: () => Promise<Buff
   } else {
     mismatch = 0;
   }
-
-  saveImage(filename, Subfolder.ACTUAL, actualImage);
   return mismatch;
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation content changes
- [ ] Other


## What is the current behavior?

actual image is used for comparison if no expected image is present;
test suite succeeds. If the developer forgets to review the expected image the test has no value

## What is the new behavior?

add option not to use actual image as expected image;
if set it returns a high mismatch to indicate a failing test

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information